### PR TITLE
Fix transaction commands for conway era

### DIFF
--- a/scripts/transfer
+++ b/scripts/transfer
@@ -5,7 +5,7 @@ if [ -z "$1" ] || [ -z "$2" ] || [ -z "$3" ] || [ -z "$4" ]; then
   exit 1
 fi
 
-cardano-cli transaction build \
+cardano-cli conway transaction build \
 --tx-in $4 \
 --tx-out "$(addr $2)+$(ada $3)" \
 --change-address $(addr $1) \

--- a/scripts/tx-hash
+++ b/scripts/tx-hash
@@ -5,5 +5,5 @@ if [ -z "$1" ]; then
     exit 1
 fi
 
-cardano-cli transaction txid \
+cardano-cli conway transaction txid \
 --tx-file "$TX_PATH/$1.signed"

--- a/scripts/tx-sign
+++ b/scripts/tx-sign
@@ -17,7 +17,7 @@ for user in "${@:2}"; do
   skeyfiles+="--signing-key-file $KEYS_PATH/$user.skey "
 done
 
-cardano-cli transaction sign \
+cardano-cli conway transaction sign \
 --tx-body-file "$tx.raw" \
 $skeyfiles \
 --out-file "$tx.signed"

--- a/scripts/tx-submit
+++ b/scripts/tx-submit
@@ -5,15 +5,15 @@ if [ -z "$1" ]; then
     exit 1
 fi
 
-cardano-cli transaction submit \
+cardano-cli conway transaction submit \
 --tx-file "$TX_PATH/$1.signed"
 
-if [ $? -eq 0 ]; then
-  cexplorer_url="cexplorer.io/tx/$(tx-hash $1)"
-  echo -e "View transaction:\n"
-  if [[ $CARDANO_NETWORK = "mainnet" ]]; then
-    echo -e "\thttps://$cexplorer_url"
-  else
-    echo -e "\thttps://$CARDANO_NETWORK.$cexplorer_url"
-  fi
-fi
+#if [ $? -eq 0 ]; then
+  #cexplorer_url="cexplorer.io/tx/$(tx-hash $1)"
+  #echo -e "View transaction:\n"
+  #if [[ $CARDANO_NETWORK = "mainnet" ]]; then
+    #echo -e "\thttps://$cexplorer_url"
+  #else
+    #echo -e "\thttps://$CARDANO_NETWORK.$cexplorer_url"
+  #fi
+#fi

--- a/scripts/tx-view
+++ b/scripts/tx-view
@@ -5,5 +5,5 @@ if [ -z "$1" ]; then
     exit 1
 fi
 
-cardano-cli transaction view \
+cardano-cli debug transaction view \
 --tx-body-file "$TX_PATH/$1.raw"

--- a/scripts/tx-witness
+++ b/scripts/tx-witness
@@ -13,7 +13,7 @@ fi
 for user in "${@:2}"; do
   out="$TX_PATH/$1-$user.witness"
 
-  cardano-cli transaction witness \
+  cardano-cli conway transaction witness \
   --tx-body-file "$TX_PATH/$1.raw" \
   --signing-key-file "$KEYS_PATH/$user.skey" \
   --out-file $out


### PR DESCRIPTION
Several transaction signing, viewing and submission commands have been changed in the Conway era.  This PR fixes those commands to work as of cardano-cli 10.1.3.